### PR TITLE
Reuse existing vpc and provide vpc, subnet and sg ids from variables

### DIFF
--- a/ozone-apx-nudge-staging/node-groups.tf
+++ b/ozone-apx-nudge-staging/node-groups.tf
@@ -49,17 +49,17 @@ locals {
 
 locals {
   source       = "../tf-modules/node-group"
-  subnet_1a    = [module.networking.private_subnets_ids[0]]
-  subnet_1b    = [module.networking.private_subnets_ids[1]]
-  subnet_1c    = [module.networking.private_subnets_ids[2]]
-  subnet_multi = module.networking.private_subnets_ids
+  subnet_1a    = var.private_subnets_ids_zone_a
+  subnet_1b    = var.private_subnets_ids_zone_b
+  subnet_1c    = var.private_subnets_ids_zone_c
+  subnet_multi = concat(var.private_subnets_ids_zone_a, var.private_subnets_ids_zone_b, var.private_subnets_ids_zone_c)
 }
 
 locals {
   common_conf = {
     cluster_name       = var.cluster_name
     ec2_key            = var.instance_key
-    security_group_ids = module.networking.security_groups_ids
+    security_group_ids = var.security_groups_ids
     node_role_arn      = module.default-iam.node_group_role_arn
   }
 }
@@ -99,15 +99,15 @@ module "ng-standby" {
   common_config      = local.common_conf
   source             = "../tf-modules/node-group"
   scaling_config = {
-    min_size     = 1
-    desired_size = 1
+    min_size     = 0
+    desired_size = 0
     max_size     = 2
   }
 }
 
 module "ng-spot" {
   depends_on         = [aws_eks_cluster.eks_cluster]
-  name               = "ng-spoty"
+  name               = "ng-spot"
   instance_types     = [local.spot_general_16C_64G]
   provision_type     = local.SPOT
   autoscaler_enabled = true
@@ -115,7 +115,7 @@ module "ng-spot" {
   common_config      = local.common_conf
   source             = "../tf-modules/node-group"
   scaling_config = {
-    min_size     = 1
+    min_size     = 0
     desired_size = 1
     max_size     = 2
   }

--- a/ozone-apx-nudge-staging/variables.auto.tfvars
+++ b/ozone-apx-nudge-staging/variables.auto.tfvars
@@ -7,9 +7,15 @@ sso_profile    = "default"
 
 /* Variables for Networking module */
 
-vpc_cidr             = "10.0.0.0/16"
-private_subnets_cidr = ["10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/19"]
-public_subnets_cidr  = ["10.0.96.0/19", "10.0.128.0/19", "10.0.160.0/19"]
+# vpc_cidr             = "10.0.0.0/16"
+# private_subnets_cidr = ["10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/19"]
+# public_subnets_cidr  = ["10.0.96.0/19", "10.0.128.0/19", "10.0.160.0/19"]
+
+vpc_id                     = ""
+private_subnets_ids_zone_a = []
+private_subnets_ids_zone_b = []
+private_subnets_ids_zone_c = []
+security_groups_ids        = []
 
 /* Variables for EKS */
 

--- a/ozone-apx-nudge-staging/variables.tf
+++ b/ozone-apx-nudge-staging/variables.tf
@@ -26,21 +26,45 @@ variable "sso_profile" {
   variables for networking module
 ---------------------------------*/
 
-variable "vpc_cidr" {
+# variable "vpc_cidr" {
+#   type        = string
+#   description = "The CIDR block of the vpc"
+# }
+
+# variable "public_subnets_cidr" {
+#   type        = list(string)
+#   description = "The CIDR block for the public subnet"
+# }
+
+# variable "private_subnets_cidr" {
+#   type        = list(string)
+#   description = "The CIDR block for the private subnet"
+# }
+
+variable "vpc_id" {
   type        = string
-  description = "The CIDR block of the vpc"
+  description = "id of the vpc"
 }
 
-variable "public_subnets_cidr" {
+variable "private_subnets_ids_zone_a" {
   type        = list(string)
-  description = "The CIDR block for the public subnet"
+  description = "list of private subnet ids for zone a"
 }
 
-variable "private_subnets_cidr" {
+variable "private_subnets_ids_zone_b" {
   type        = list(string)
-  description = "The CIDR block for the private subnet"
+  description = "list of private subnet ids for zone b"
 }
 
+variable "private_subnets_ids_zone_c" {
+  type        = list(string)
+  description = "list of private subnet ids for zone c"
+}
+
+variable "security_groups_ids" {
+  type        = list(string)
+  description = "list of security group ids"
+}
 
 /*-------------------------------
   variables for EKS cluster


### PR DESCRIPTION
For nudging setup:
- removed networking module import
- uses provided vpc id
- used provided subnets ids and security group ids from input variables